### PR TITLE
feat: Add citation amendment templates

### DIFF
--- a/request-citation-change-template.md
+++ b/request-citation-change-template.md
@@ -1,0 +1,35 @@
+# pyhf citation change from ICHEP to JOSS request
+
+## Email Subject
+
+Request for pyhf Citation Amendment in '[PAPER TITLE]' paper
+
+## Email Body
+
+Hi [ALL AUTHORS FIRST NAMES],
+
+We happened to see your recent paper "[PAPER TITLE](HYPERLINK TO PAPER)" on the arXiv and were quite happy to see that you used and cited pyhf in it --- thanks!
+However, the citation for pyhf is wrong as it is cites the [ICHEP 2022 proceedings](https://pos.sissa.it/414/245), and not the [Journal of Open Source Software paper](https://joss.theoj.org/papers/10.21105/joss.02823), as given on the [Use and Citations page of the pyhf docs](https://pyhf.readthedocs.io/en/stable/citations.html#citation) and [the citation APIs](https://pyhf.readthedocs.io/en/stable/cli.html#cmdoption-pyhf-cite).
+Would you please correct the citation to the JOSS paper?
+
+```
+@article{pyhf_joss,
+  doi = {10.21105/joss.02823},
+  url = {https://doi.org/10.21105/joss.02823},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {58},
+  pages = {2823},
+  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
+  title = {pyhf: pure-Python implementation of HistFactory statistical models},
+  journal = {Journal of Open Source Software}
+}
+```
+
+We appreciate that ICHEP results might turn up first if people search "pyhf ICHEP" instead of "pyhf", but we've tried to make this clear by noting in the comments for the [corresponding arXiv preprint](https://arxiv.org/abs/2211.15838)
+
+"... If you are looking to cite pyhf as software, please follow the citation instructions at this https URL".
+
+Best,
+The pyhf dev team (Lukas, Matthew, and Giordon)

--- a/request-zenodo-cite-template.md
+++ b/request-zenodo-cite-template.md
@@ -1,0 +1,43 @@
+# pyhf citation Zenodo extension request
+
+## Email Subject
+
+Request for pyhf Citation Amendment in '[PAPER TITLE]' paper
+
+## Email Body
+
+Hi [ALL AUTHORS FIRST NAMES],
+
+We happened to see your recent paper "[PAPER TITLE](HYPERLINK TO PAPER)" on the arXiv and were quite happy to see that you used and cited pyhf in it --- thanks!
+Would you mind extending the citation of pyhf through, so that in addition to the JOSS paper citation that you have in there now the Zenodo DOI citation would be added (as given on the [Use and Citations page of the pyhf docs](https://pyhf.readthedocs.io/en/stable/citations.html#citation) and [the citation APIs](https://pyhf.readthedocs.io/en/stable/cli.html#cmdoption-pyhf-cite)).
+
+Example for pyhf v0.7.6:
+
+```
+@software{pyhf,
+  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
+  title = "{pyhf: v0.7.6}",
+  version = {0.7.6},
+  doi = {10.5281/zenodo.1169739},
+  url = {https://doi.org/10.5281/zenodo.1169739},
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.7.6}
+}
+
+@article{pyhf_joss,
+  doi = {10.21105/joss.02823},
+  url = {https://doi.org/10.21105/joss.02823},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {58},
+  pages = {2823},
+  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
+  title = {pyhf: pure-Python implementation of HistFactory statistical models},
+  journal = {Journal of Open Source Software}
+}
+```
+
+Would you mind submitting an extended citation to arXiv? It is important for pyhf's future as a project that we're able to show use citations for it, and having both the Zenodo and JOSS citations help.
+
+Best,
+The pyhf dev team (Lukas, Matthew, and Giordon)


### PR DESCRIPTION
* Add citation amendment email templates for citations that don't include the Zenodo DOI and citations that cite the ICHEP 2022 proceedings instead of the JOSS paper.